### PR TITLE
修正游戏窗口英文名称为"Infinity Nikki"（现在多一个空格）

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ def enum_windows_callback(hwnd, hwnds):
     try:
         class_name = win32gui.GetClassName(hwnd).strip()
         window_name = win32gui.GetWindowText(hwnd).strip()
-        if (window_name == 'InfinityNikki' or window_name == '无限暖暖') and class_name == 'UnrealWindow':
+        if (window_name == 'Infinity Nikki' or window_name == 'InfinityNikki' or window_name == '无限暖暖') and class_name == 'UnrealWindow':
             hwnds.append(hwnd)
     except:
         pass


### PR DESCRIPTION
如图，现在英文的窗口名称多了一个空格
![image](https://github.com/user-attachments/assets/3101b5e5-2864-45fe-9bfb-b6b046ac8609)
